### PR TITLE
feat: pruningの再現性確保

### DIFF
--- a/rulecosi/RuleCOSI.py
+++ b/rulecosi/RuleCOSI.py
@@ -448,6 +448,7 @@ class RuleCOSIClassifier(ClassifierMixin, BaseRuleCOSI):
         self.combined_rulesets_ = self.combiner.combine_rulesets(
             self.simplified_ruleset_
         )
+        print(f"combined ruleset length: {len(self.combined_rulesets_.rules)}")
         print("-----combine completed-----")
 
         print("-----pruning start-----")
@@ -463,6 +464,7 @@ class RuleCOSIClassifier(ClassifierMixin, BaseRuleCOSI):
         self.pruned_rulesets_ = self.pruner.sequential_covering_pruning(
             self.combined_rulesets_
         )
+        print(f"pruned ruleset length: {len(self.pruned_rulesets_.rules)}")
         print("-----pruning completed-----")
 
     def _more_tags(self):

--- a/rulecosi/pruning.py
+++ b/rulecosi/pruning.py
@@ -35,17 +35,18 @@ class SCPruning:
             self.compute_heuristics()
 
             self.unpruned_rulesets.rules.sort(
-                key=lambda rule: (rule.conf, rule.cov, rule.supp), reverse=True
+                key=lambda rule: (rule.cov, rule.conf, rule.str, id(rule)),
+                reverse=True,
             )
 
             # ソート後のヒューリスティクスを表示
             # for i, rule in enumerate(self.unpruned_rulesets.rules[:5]):
-            # print(f"順位: {i+1}")
-            # print(f"  カバレッジ (Coverage): {rule.cov}")
-            # print(f"  信頼度 (Confidence): {rule.conf}")
-            # print(f"  サポート率 (Support): {rule.supp}")
-            # print(f"  ルール条件セット (Rule Conditions): {rule}")
-            # print("-" * 10)
+            #     print(f"順位: {i+1}")
+            #     print(f"  カバレッジ (Coverage): {rule.cov}")
+            #     print(f"  信頼度 (Confidence): {rule.conf}")
+            #     print(f"  サポート率 (Support): {rule.supp}")
+            #     print(f"  ルール条件セット (Rule Conditions): {rule}")
+            #     print("-" * 10)
 
             found_rule = False
             for i, rule in enumerate(self.unpruned_rulesets.rules):

--- a/rulecosi/pruning.py
+++ b/rulecosi/pruning.py
@@ -32,12 +32,8 @@ class SCPruning:
         self.pruned_ruleset = set()
 
         while len(self.unpruned_rulesets.rules) > 0 and len(self.remaining_data) > 0:
-            self.compute_heuristics()
-
-            self.unpruned_rulesets.rules.sort(
-                key=lambda rule: (rule.cov, rule.conf, rule.str, id(rule)),
-                reverse=True,
-            )
+            self.compute_heuristics(self.unpruned_rulesets)
+            self.sort_heuristics(self.unpruned_rulesets)
 
             # ソート後のヒューリスティクスを表示
             # for i, rule in enumerate(self.unpruned_rulesets.rules[:5]):
@@ -76,15 +72,24 @@ class SCPruning:
             classes=self.classes_,
         )
 
+        self.compute_heuristics(self.pruned_ruleset)
+        self.sort_heuristics(self.pruned_ruleset)
+
         return self.pruned_ruleset
 
     # ヒューリスティクスを再計算
-    def compute_heuristics(self):
+    def compute_heuristics(self, ruleset):
         if not self.rule_heuristics:
             raise ValueError("Rule heuristics object not initialized.")
 
         self.rule_heuristics.compute_rule_heuristics(
-            ruleset=self.unpruned_rulesets,
+            ruleset=ruleset,
             not_cov_mask=self.not_cov_mask,
             recompute=True,
+        )
+
+    def sort_heuristics(self, ruleset):
+        ruleset.rules.sort(
+            key=lambda rule: (rule.cov, rule.conf, rule.str, id(rule)),
+            reverse=True,
         )


### PR DESCRIPTION
# 目的 | Purpose
<!-- このプルリクエストがなぜ必要かを書く --> 
プルーニング後のルール数が毎回変わってしまっていたため修正

# 関連項目 | Related Items
<!-- チケットやWiki, Google DriveのURLを貼る -->
* #11 

# 変更内容 | Changes
<!-- どのような変更を行ったかを書く --> 
* ソートの優先順位を`cov > conf`に変更
* ソートに条件の文字列(rule.str)も含める
* heuristicsの計算とソート部分をメソッド化
* returnの前にheuristicsの再計算とソートを実行

# 補足情報 | Additional Information
<!-- 特殊な対応や未対応の事項があれば記載 --> 
combineした段階で、cov, confが完全に一致しているルールが多数存在しており、以前のソートだとcov, confが完全一致しているルールの順序があいまいになっていたと考えられる。ソートに条件の文字列を含ませることによって再現性を確保しました。