### PR TITLE
Feature/early-stopping, default-ruleset

### DIFF
--- a/experiment/experiment.py
+++ b/experiment/experiment.py
@@ -101,7 +101,7 @@ class ExpBase:
             train_data, val_data = self.train.iloc[train_idx], self.train.iloc[val_idx]
             model, time = self.each_fold(i_fold, train_data, val_data)
 
-            print("rule作成成功")
+            # print("rule作成成功")
             # exit()  # RuleCOSI+のアルゴリズムを作成しないと以下を実行できない。
 
             score = cal_metrics(model, val_data, self.columns, self.target_column)

--- a/rulecosi/RuleCOSI.py
+++ b/rulecosi/RuleCOSI.py
@@ -463,6 +463,13 @@ class RuleCOSIClassifier(ClassifierMixin, BaseRuleCOSI):
             )
             # print(f"generalized ruleset length: {len(self.simplified_ruleset_.rules)}")
 
+            # early stopping
+            self.simplified_ruleset_.compute_class_perf(
+                self.X_, self.y_, metric=self.metric
+            )
+            if self.simplified_ruleset_.metric(metric=self.metric) == 1:
+                break
+
         self.add_default_ruleset()
 
     def _more_tags(self):

--- a/rulecosi/RuleCOSI.py
+++ b/rulecosi/RuleCOSI.py
@@ -23,6 +23,7 @@ from .pruning import SCPruning
 from .generalize import Generalize
 from rule_making import RuleSet
 from rule_making import RuleHeuristics
+from .utils import sort_ruleset
 
 
 def _ensemble_type(ensemble):
@@ -435,9 +436,12 @@ class RuleCOSIClassifier(ClassifierMixin, BaseRuleCOSI):
         self.processed_rulesets_, self._global_condition_map, self._rule_heuristics = (
             self._rule_extractor.rule_extraction()
         )
-        self.simplified_ruleset_ = _simplify_rulesets(
+        self.processed_rulesets_ = _simplify_rulesets(
             self.processed_rulesets_, self._global_condition_map
         )
+
+        for ruleset in self.processed_rulesets_:
+            sort_ruleset(ruleset)
 
         self.simplified_ruleset_ = self.processed_rulesets_[0]
 
@@ -458,6 +462,8 @@ class RuleCOSIClassifier(ClassifierMixin, BaseRuleCOSI):
                 self.simplified_ruleset_
             )
             # print(f"generalized ruleset length: {len(self.simplified_ruleset_.rules)}")
+
+        self.add_default_ruleset()
 
     def _more_tags(self):
         return {"binary_only": True}
@@ -594,3 +600,6 @@ class RuleCOSIClassifier(ClassifierMixin, BaseRuleCOSI):
                 f"Invalid argument '{str}' passed to class_maker. "
                 "Expected one of: 'combine', 'pruning', 'generalize'."
             )
+
+    def add_default_ruleset(self):
+        pass

--- a/rulecosi/combine.py
+++ b/rulecosi/combine.py
@@ -1,6 +1,8 @@
 import numpy as np
+
 from rule_making import Rule, RuleSet
 from ._simplify_rulesets import _simplify_conditions
+from .utils import sort_ruleset
 
 
 class Combine:
@@ -27,6 +29,8 @@ class Combine:
         combined_rule = set()
         # print("rs1 : ", len(rs1.rules))
         # print("rs2 : ", len(rs2.rules))
+        sort_ruleset(rs1)
+        sort_ruleset(rs2)
         for r1 in rs1:
             for r2 in rs2:
                 # print("r1 conditions: ", r1.A)
@@ -79,5 +83,6 @@ class Combine:
             condition_map=self.global_condition_map,
             classes=self.classes_,
         )
+        sort_ruleset(combined_rulesets)
 
         return combined_rulesets

--- a/rulecosi/generalize.py
+++ b/rulecosi/generalize.py
@@ -1,7 +1,8 @@
-from rule_making import RuleSet, Rule
-
 from math import sqrt
 from scipy.stats import norm
+
+from rule_making import RuleSet, Rule
+from .utils import sort_ruleset
 
 
 class Generalize:
@@ -84,10 +85,7 @@ class Generalize:
         )
         self.compute_heuristics(self.generalized_ruleset)
         # 信頼度とカバレッジでソート
-        self.generalized_ruleset.rules.sort(
-            key=lambda rule: (rule.cov, rule.conf, rule.str, id(rule)),
-            reverse=True,
-        )
+        sort_ruleset(self.generalized_ruleset)
 
         return self.generalized_ruleset
 

--- a/rulecosi/pruning.py
+++ b/rulecosi/pruning.py
@@ -1,5 +1,6 @@
 import numpy as np
 from rule_making import RuleSet
+from .utils import sort_ruleset
 
 
 class SCPruning:
@@ -33,7 +34,7 @@ class SCPruning:
 
         while len(self.unpruned_rulesets.rules) > 0 and len(self.remaining_data) > 0:
             self.compute_heuristics(self.unpruned_rulesets)
-            self.sort_heuristics(self.unpruned_rulesets)
+            sort_ruleset(self.unpruned_rulesets)
 
             # ソート後のヒューリスティクスを表示
             # for i, rule in enumerate(self.unpruned_rulesets.rules[:5]):
@@ -73,7 +74,7 @@ class SCPruning:
         )
 
         self.compute_heuristics(self.pruned_ruleset)
-        self.sort_heuristics(self.pruned_ruleset)
+        sort_ruleset(self.pruned_ruleset)
 
         return self.pruned_ruleset
 
@@ -86,10 +87,4 @@ class SCPruning:
             ruleset=ruleset,
             not_cov_mask=self.not_cov_mask,
             recompute=True,
-        )
-
-    def sort_heuristics(self, ruleset):
-        ruleset.rules.sort(
-            key=lambda rule: (rule.cov, rule.conf, rule.str, id(rule)),
-            reverse=True,
         )

--- a/rulecosi/utils.py
+++ b/rulecosi/utils.py
@@ -1,0 +1,15 @@
+from operator import attrgetter
+
+
+def sort_ruleset(ruleset):
+    """Sort the ruleset in place according to the rule_order parameter.
+
+    :param ruleset: ruleset to be ordered
+    """
+    sorting_list = ["conf", "cov", "supp"]
+    if len(ruleset.rules) == 0:
+        return
+
+    ruleset.rules.sort(key=lambda rule: (-1 * len(rule.A), rule.str))
+    for attr in sorting_list:
+        ruleset.rules.sort(key=attrgetter(attr), reverse=True)


### PR DESCRIPTION
# 目的 | Purpose
<!-- このプルリクエストがなぜ必要かを書く --> 
* 作成したルールで賄えていないデータが存在するため、デフォルトルールを追加する。
* early-stoppingの導入

# 関連項目 | Related Items
<!-- チケットやWiki, Google DriveのURLを貼る -->
* #32 
* #46 

# 変更内容 | Changes
<!-- どのような変更を行ったかを書く --> 
ソートのメソッド化：
* 拡張性を高めるために、utils.pyに記述。

default ruleの作成：
* add_default_rulesetメソッドの追加
* 使用されていないデータのラベルの最頻値(majority_label)を取る。
* 条件セット A は空、予測されるクラスはmajority_labelとしてルールを作成

early stoppingの導入：
* rules.pyに作成済みのmetricメソッドを使用。
* F1値を用いて早期停止
